### PR TITLE
refactor: 优化分享卡片背景亮度判断和文字颜色适配

### DIFF
--- a/packages/app/src/components/dialogs/ShareCardDialog/components/MusicCard/PhoneCard.vue
+++ b/packages/app/src/components/dialogs/ShareCardDialog/components/MusicCard/PhoneCard.vue
@@ -31,7 +31,7 @@ const playOffset = computed(() => 100 - progress.value);
 
 // 计算背景图片亮度
 const { isDark } = useImageBrightness(() => props.coverUrl, {
-  threshold: 180,
+  threshold: 170,
 });
 
 // 背景样式（有封面时使用封面作为模糊背景）
@@ -60,7 +60,7 @@ const handleLyricsClick = () => {
     <!-- 背景层 -->
     <div
       class="background-layer absolute top-0 left-0 right-0 bottom-0 inset-0 z-[1]"
-      :class="{ active: coverUrl, bright: isDark === false }"
+      :class="{ active: coverUrl, bright: !isDark }"
       :style="backgroundStyle"
     ></div>
 

--- a/packages/app/src/components/dialogs/ShareCardDialog/components/MusicCard/PlayerCard.vue
+++ b/packages/app/src/components/dialogs/ShareCardDialog/components/MusicCard/PlayerCard.vue
@@ -32,7 +32,7 @@ const messageText = ref('Good morning');
 
 // 计算背景图片亮度
 const { isDark } = useImageBrightness(() => props.coverUrl, {
-  threshold: 180,
+  threshold: 170,
 });
 
 // 背景样式（有封面时使用封面作为模糊背景）
@@ -66,7 +66,7 @@ const handleTextInput = (event, type) => {
     <!-- 背景层 -->
     <div
       class="background-layer absolute inset-0 z-[1]"
-      :class="{ active: coverUrl, bright: isDark === false }"
+      :class="{ active: coverUrl, bright: !isDark }"
       :style="backgroundStyle"
     ></div>
 
@@ -144,7 +144,8 @@ const handleTextInput = (event, type) => {
       >
         <!-- 可编辑文字 -->
         <div
-          class="text-content relative z-10 flex flex-col justify-center items-center gap-2 size-full text-[15px] text-white/85"
+          class="text-content relative z-10 flex flex-col justify-center items-center gap-2 size-full text-[15px]"
+          :class="[isDark ? 'text-white/85' : ' text-black/75']"
           contenteditable="true"
           @input="handleTextInput($event, 'greeting')"
         ></div>


### PR DESCRIPTION
- 调整亮度阈值从 180 降至 170，提升亮度判断准确性
- 简化 isDark 布尔判断逻辑（isDark === false → !isDark）
- 根据背景亮度动态调整文字颜色（亮背景用深色文字，暗背景用浅色文字）